### PR TITLE
fix: Update links to new getretake GH org

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ curl -sSL https://install.python-poetry.org | python -
 poetry install
 ```
 
-3. Build the SDK locally.
+3. Build the SDK locally
 
 ```
 poetry build
 ```
 
-This command will build and install the `retake` SDK into your local environment.
+This command will build and install the `retake` SDK locally. You can now `import retake` from a Python environment.
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Installation
 
-Welcome! If you are not a contributor and just want to use Retake, please proceed to the [stable version](https://github.com/retake-earth/retake/tree/main).
+Welcome! If you are not a contributor and just want to use Retake, please proceed to the [stable version](https://github.com/getretake/retake/tree/main).
 
 To install the Retake Python SDK:
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -17,7 +17,7 @@
   },
   "topbarCtaButton": {
     "type": "github",
-    "url": "https://github.com/retake-earth/connect"
+    "url": "https://github.com/getretake/retake"
   },
   "navigation": [
     {
@@ -54,7 +54,7 @@
     }
   ],
   "footerSocials": {
-    "github": "https://github.com/retake-earth/connect"
+    "github": "https://github.com/getretake/retake"
   },
   "backgroundImage": "/background.png"
 }


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
Update links to new getretake GH org

**Why**
We changed our github org from retake-earth to get-retake

**How**

**Tests**