### PR TITLE
feat: Add CUDA to GHA Runners

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,9 +3,9 @@ name: "Run tests"
 on:
   pull_request:
     branches: [dev, staging, main]
-    paths:
-      - "core/**"
-      - "retake/**"
+    # paths:
+    #   - "core/**"
+    #   - "retake/**"
 
 jobs:
   build:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,10 +36,9 @@ jobs:
           cd cudnn-linux-x86_64-8.9.2.26_cuda12-archive
           
 
-
-          sudo cp include/cudnn.h /usr/local/cuda-12.1/include
-          sudo cp lib/libcudnn* /usr/local/cuda-12.1/lib64
-          sudo chmod a+r /usr/local/cuda-12.1/include/cudnn.h /usr/local/cuda-12.1/lib64/libcudnn*
+          sudo cp include/cudnn.h /usr/lib/cuda/include
+          sudo cp lib/libcudnn* /usr/lib/cuda/lib64
+          sudo chmod a+r /usr/lib/cuda/include/cudnn.h /usr/lib/cuda/lib64/libcudnn*
 
 
       - name: Install Poetry

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,4 +58,5 @@ jobs:
       # due to CUDA issue in GH runner
       - name: Run Pytest
         run: |
+          export LD_LIBRARY_PATH=/home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
           poetry run pytest --ignore=core/transform/tests/test_sentence_transformers.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,17 +24,19 @@ jobs:
 
 
 
-      - name: Set up CUDA
+      - name: Install CUDA & CUDNN
         run: |
-          cuda_version=cuda12.1
-          cudnn_version=8.9.3.*
 
           sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
 
-          sudo apt-get install libcudnn8=${cudnn_version}-1+${cuda_version}
-          sudo apt-get install libcudnn8-dev=${cudnn_version}-1+${cuda_version}
-          sudo apt-get install libcudnn8-samples=${cudnn_version}-1+${cuda_version}
+          tar -zvxf cudnn-linux-x86_64-8.9.0.131_cuda12-archive.tar.xz
 
+          cd cudnn-linux-x86_64-8.9.0.131_cuda12-archive
+          
+          sudo cp include/cudnn.h /usr/local/cuda-12.1/include
+          sudo cp lib/libcudnn* /usr/local/cuda-12.1/lib64
+          
+          sudo chmod a+r /usr/local/cuda-12.1/include/cudnn.h /usr/local/cuda-12.1/lib64/libcudnn*
 
 
       - name: Install Poetry

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,11 +22,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+
+      - name: Debugging with ssh
+        uses: lhotari/action-upterm@v1
+        
+
       # Based on https://www.cloudbooklet.com/how-to-set-up-deep-learning-architecture-on-ubuntu-22-04/#install-cuda-toolkit-and-cu-dnn
       - name: Install CUDA & cuDNN
         run: |
           # Install CUDA
-          sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
+          # TODO: reactivate this once the rest works, to save time for now
+          # sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
 
           # Install cuDNN
           # The CUDNN package is initially downloaded from https://developer.nvidia.com/rdp/cudnn-archive, which requires a login to Nvidia Developer Program
@@ -37,6 +43,10 @@ jobs:
           sudo cp include/cudnn.h /usr/lib/cuda/include
           sudo cp lib/libcudnn* /usr/lib/cuda/lib64
           sudo chmod a+r /usr/lib/cuda/include/cudnn.h /usr/lib/cuda/lib64/libcudnn*
+
+          
+          locate cudnn | grep /cudnn$
+
 
 
           export LD_LIBRARY_PATH=/home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,21 +22,37 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python -
+  
+      - name: Configure Poetry
+        run: |
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+
+      - name: Install dependencies
+        run: |
+          poetry install
 
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        
 
       # Based on https://www.cloudbooklet.com/how-to-set-up-deep-learning-architecture-on-ubuntu-22-04/#install-cuda-toolkit-and-cu-dnn
-      - name: Install CUDA, cuDNN & NCCL
+      - name: Install CUDA & cuDNN
         run: |
-          # Install CUDA (we need 11.7 for our tests)
-          # See here: https://developer.nvidia.com/cuda-11-7-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_network
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
-          sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
-          sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
-          sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
-          sudo apt-get update
-          sudo apt-get -y install cuda
-          echo $(nvcc --version)
+          # Install CUDA
+          # TODO: reactivate this once the rest works, to save time for now
+          sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
+
+
+
+
+
+
+
 
           # Install cuDNN
           # The CUDNN package is initially downloaded from https://developer.nvidia.com/rdp/cudnn-archive, which requires a login to Nvidia Developer Program
@@ -49,48 +65,26 @@ jobs:
           sudo chmod a+r /usr/lib/cuda/include/cudnn.h /usr/lib/cuda/lib64/libcudnn*
 
 
-
-          # Install NCCL
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
-          sudo dpkg -i cuda-keyring_1.0-1_all.deb
-          sudo apt-get update
-          sudo apt-get -y install libnccl2 libnccl-dev
-
-
-
-
-
           
-          # locate cudnn | grep /cudnn$
+          locate cudnn | grep /cudnn$
 
 
 
           export LD_LIBRARY_PATH=/usr/lib/cuda/lib64:$LD_LIBRARY_PATH
           
-          # export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
 
-          # sudo ln -s /usr/lib/x86_64-linux-gnu/libcupti.so /usr/lib/cuda/lib64/libcupti.so.11.7
+          sudo ln -s /usr/lib/cuda/lib64/libcupti.so.11.7 /usr/lib/x86_64-linux-gnu/libcupti.so
 
 
 
 
-          # cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
-          # sudo ldconfig
-          # ls -l /home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/libcudnn.so.8
+          cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
+          sudo ldconfig
+          ls -l /home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/libcudnn.so.8
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python -
 
-      - name: Configure Poetry
-        run: |
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-
-      - name: Install dependencies
-        run: |
-          poetry install
 
       # Tech Debt: Disable sentence_transformer test in GH actions
       # due to CUDA issue in GH runner

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,16 @@ jobs:
 
       - name: Set up CUDA
         run: |
+          cuda_version=cuda12.1
+          cudnn_version=8.9.3.*
+
           sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
+
+          sudo apt-get install libcudnn8=${cudnn_version}-1+${cuda_version}
+          sudo apt-get install libcudnn8-dev=${cudnn_version}-1+${cuda_version}
+          sudo apt-get install libcudnn8-samples=${cudnn_version}-1+${cuda_version}
+
+
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,9 +36,10 @@ jobs:
           poetry install
 
 
+
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        
+
 
       # Based on https://www.cloudbooklet.com/how-to-set-up-deep-learning-architecture-on-ubuntu-22-04/#install-cuda-toolkit-and-cu-dnn
       - name: Install CUDA & cuDNN

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,24 +22,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-
       # Based on https://www.cloudbooklet.com/how-to-set-up-deep-learning-architecture-on-ubuntu-22-04/#install-cuda-toolkit-and-cu-dnn
-      - name: Install CUDA & CUDNN
+      - name: Install CUDA & cuDNN
         run: |
-          # Install Cuda
+          # Install CUDA
           sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
 
-          # Install Cudnn
+          # Install cuDNN
           # The CUDNN package is initially downloaded from https://developer.nvidia.com/rdp/cudnn-archive, which requires a login to Nvidia Developer Program
           wget -q https://retake-ci-assets.s3.amazonaws.com/cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
           tar -xf cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
           cd cudnn-linux-x86_64-8.9.2.26_cuda12-archive
           
-
           sudo cp include/cudnn.h /usr/lib/cuda/include
           sudo cp lib/libcudnn* /usr/lib/cuda/lib64
           sudo chmod a+r /usr/lib/cuda/include/cudnn.h /usr/lib/cuda/lib64/libcudnn*
 
+
+          export LD_LIBRARY_PATH=/home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
+          sudo ldconfig
+          ls -l /home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/libcudnn.so.8
 
       - name: Install Poetry
         run: |
@@ -59,4 +61,8 @@ jobs:
       - name: Run Pytest
         run: |
           export LD_LIBRARY_PATH=/home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
+          sudo ldconfig
+          ls -l /home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/libcudnn.so.8
+
+
           poetry run pytest --ignore=core/transform/tests/test_sentence_transformers.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,45 +45,32 @@ jobs:
       - name: Install CUDA & cuDNN
         run: |
           # Install CUDA
-          # TODO: reactivate this once the rest works, to save time for now
-          sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
-
-
-
-
-
-
-
+          cd /temp
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
+          sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
+          wget https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda-repo-ubuntu2204-11-7-local_11.7.1-515.65.01-1_amd64.deb
+          sudo dpkg -i cuda-repo-ubuntu2204-11-7-local_11.7.1-515.65.01-1_amd64.deb
+          sudo cp /var/cuda-repo-ubuntu2204-11-7-local/cuda-*-keyring.gpg /usr/share/keyrings/
+          sudo apt-get update
+          sudo apt-get -y install cuda
+          
+          # Environment variables
+          sudo nano ~/.bashrc
+          export PATH=/usr/local/cuda-11.7/bin${PATH:+:${PATH}}
+          export LD_LIBRARY_PATH=/usr/local/cuda-11.7/lib64:$LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-11.7/include:$LD_LIBRARY_PATH
 
           # Install cuDNN
-          # The CUDNN package is initially downloaded from https://developer.nvidia.com/rdp/cudnn-archive, which requires a login to Nvidia Developer Program
-          wget -q https://retake-ci-assets.s3.amazonaws.com/cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
-          tar -xf cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
-          cd cudnn-linux-x86_64-8.9.2.26_cuda12-archive
-          
-          sudo cp include/cudnn.h /usr/lib/cuda/include
-          sudo cp lib/libcudnn* /usr/lib/cuda/lib64
-          sudo chmod a+r /usr/lib/cuda/include/cudnn.h /usr/lib/cuda/lib64/libcudnn*
-
-
-          
-          locate cudnn | grep /cudnn$
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
+          sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
+          sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+          sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
+          sudo apt-get update
+          sudo apt-get install libcudnn8=8.5.0.*-1+cuda11.7
+          sudo apt-get install libcudnn8-dev=8.5.0.*-1+cuda11.7
 
 
 
-          export LD_LIBRARY_PATH=/usr/lib/cuda/lib64:$LD_LIBRARY_PATH
-          
-          export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
-
-
-          sudo ln -s /usr/lib/cuda/lib64/libcupti.so.11.7 /usr/lib/x86_64-linux-gnu/libcupti.so
-
-
-
-
-          cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
-          sudo ldconfig
-          ls -l /home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/libcudnn.so.8
 
 
 
@@ -91,7 +78,4 @@ jobs:
       # due to CUDA issue in GH runner
       - name: Run Pytest
         run: |
-          export LD_LIBRARY_PATH=/home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
-
-
           poetry run pytest --ignore=core/transform/tests/test_sentence_transformers.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: "Run tests"
 
 on:
   pull_request:
-    branches: [dev, staging, main]
+    branches: [dev, staging, main, feat/more-tests]
     # paths:
     #   - "core/**"
     #   - "retake/**"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
           # Install Cudnn
           # The CUDNN package is initially downloaded from https://developer.nvidia.com/rdp/cudnn-archive, which requires a login to Nvidia Developer Program
-          wget https://retake-ci-assets.s3.amazonaws.com/cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
+          wget -q https://retake-ci-assets.s3.amazonaws.com/cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
           tar -zvxf cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
           cd cudnn-linux-x86_64-8.9.2.26_cuda12-archive
           

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
           # Install Cudnn
           # The CUDNN package is initially downloaded from https://developer.nvidia.com/rdp/cudnn-archive, which requires a login to Nvidia Developer Program
           wget -q https://retake-ci-assets.s3.amazonaws.com/cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
-          tar -zvxf cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
+          tar -xf cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
           cd cudnn-linux-x86_64-8.9.2.26_cuda12-archive
           
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python -
-  
+
       - name: Configure Poetry
         run: |
           poetry config virtualenvs.create true
@@ -46,7 +46,7 @@ jobs:
           sudo cp /var/cuda-repo-ubuntu2204-11-7-local/cuda-*-keyring.gpg /usr/share/keyrings/
           sudo apt-get -y update
           sudo apt-get -y install cuda
-          
+
           # Install cuDNN
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
           sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,10 +2,10 @@ name: "Run tests"
 
 on:
   pull_request:
-    branches: [dev, staging, main, feat/more-tests]
-    # paths:
-    #   - "core/**"
-    #   - "retake/**"
+    branches: [dev, staging, main]
+    paths:
+      - "core/**"
+      - "retake/**"
 
 jobs:
   build:
@@ -35,44 +35,35 @@ jobs:
         run: |
           poetry install
 
-
-
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
 
-
-      # Based on https://www.cloudbooklet.com/how-to-set-up-deep-learning-architecture-on-ubuntu-22-04/#install-cuda-toolkit-and-cu-dnn
+      # Based on https://medium.com/@mertguvencli/how-to-setup-nvidia-driver-cuda-toolkit-and-cudnn-in-ubuntu-20-4-ac5efedb4427
       - name: Install CUDA & cuDNN
         run: |
           # Install CUDA
-          cd /temp
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
           sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
           wget https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda-repo-ubuntu2204-11-7-local_11.7.1-515.65.01-1_amd64.deb
           sudo dpkg -i cuda-repo-ubuntu2204-11-7-local_11.7.1-515.65.01-1_amd64.deb
           sudo cp /var/cuda-repo-ubuntu2204-11-7-local/cuda-*-keyring.gpg /usr/share/keyrings/
-          sudo apt-get update
+          sudo apt-get -y update
           sudo apt-get -y install cuda
           
-          # Environment variables
-          sudo nano ~/.bashrc
-          export PATH=/usr/local/cuda-11.7/bin${PATH:+:${PATH}}
-          export LD_LIBRARY_PATH=/usr/local/cuda-11.7/lib64:$LD_LIBRARY_PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda-11.7/include:$LD_LIBRARY_PATH
-
           # Install cuDNN
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
           sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
           sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
-          sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
-          sudo apt-get update
-          sudo apt-get install libcudnn8=8.5.0.*-1+cuda11.7
-          sudo apt-get install libcudnn8-dev=8.5.0.*-1+cuda11.7
+          sudo add-apt-repository -y "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"          
+          sudo apt-get -y update
+          sudo apt-get -y install libcudnn8=8.5.0.*-1+cuda11.7
+          sudo apt-get -y install libcudnn8-dev=8.5.0.*-1+cuda11.7
 
-
-
-
-
+          # Install NCCL
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
+          sudo dpkg -i cuda-keyring_1.0-1_all.deb
+          sudo apt-get -y update
+          sudo apt-get -y install libnccl2=2.18.3-1+cuda12.2 libnccl-dev=2.18.3-1+cuda12.2
 
       # Tech Debt: Disable sentence_transformer test in GH actions
       # due to CUDA issue in GH runner

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,19 +23,22 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
 
-
+      # Based on https://www.cloudbooklet.com/how-to-set-up-deep-learning-architecture-on-ubuntu-22-04/#install-cuda-toolkit-and-cu-dnn
       - name: Install CUDA & CUDNN
         run: |
-
+          # Install Cuda
           sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
 
-          tar -zvxf cudnn-linux-x86_64-8.9.0.131_cuda12-archive.tar.xz
-
-          cd cudnn-linux-x86_64-8.9.0.131_cuda12-archive
+          # Install Cudnn
+          # The CUDNN package is initially downloaded from https://developer.nvidia.com/rdp/cudnn-archive, which requires a login to Nvidia Developer Program
+          wget https://retake-ci-assets.s3.amazonaws.com/cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
+          tar -zvxf cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
+          cd cudnn-linux-x86_64-8.9.2.26_cuda12-archive
           
+
+
           sudo cp include/cudnn.h /usr/local/cuda-12.1/include
           sudo cp lib/libcudnn* /usr/local/cuda-12.1/lib64
-          
           sudo chmod a+r /usr/local/cuda-12.1/include/cudnn.h /usr/local/cuda-12.1/lib64/libcudnn*
 
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,16 +23,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        
+
 
       # Based on https://www.cloudbooklet.com/how-to-set-up-deep-learning-architecture-on-ubuntu-22-04/#install-cuda-toolkit-and-cu-dnn
-      - name: Install CUDA & cuDNN
+      - name: Install CUDA, cuDNN & NCCL
         run: |
-          # Install CUDA
-          # TODO: reactivate this once the rest works, to save time for now
-          # sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
+          # Install CUDA (we need 11.7 for our tests)
+          # See here: https://developer.nvidia.com/cuda-11-7-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_network
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
+          sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
+          sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+          sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
+          sudo apt-get update
+          sudo apt-get -y install cuda
+          echo $(nvcc --version)
 
           # Install cuDNN
           # The CUDNN package is initially downloaded from https://developer.nvidia.com/rdp/cudnn-archive, which requires a login to Nvidia Developer Program
@@ -44,14 +48,36 @@ jobs:
           sudo cp lib/libcudnn* /usr/lib/cuda/lib64
           sudo chmod a+r /usr/lib/cuda/include/cudnn.h /usr/lib/cuda/lib64/libcudnn*
 
+
+
+          # Install NCCL
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
+          sudo dpkg -i cuda-keyring_1.0-1_all.deb
+          sudo apt-get update
+          sudo apt-get -y install libnccl2 libnccl-dev
+
+
+
+
+
           
-          locate cudnn | grep /cudnn$
+          # locate cudnn | grep /cudnn$
 
 
 
-          export LD_LIBRARY_PATH=/home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
-          sudo ldconfig
-          ls -l /home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/libcudnn.so.8
+          export LD_LIBRARY_PATH=/usr/lib/cuda/lib64:$LD_LIBRARY_PATH
+          
+          # export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+
+
+          # sudo ln -s /usr/lib/x86_64-linux-gnu/libcupti.so /usr/lib/cuda/lib64/libcupti.so.11.7
+
+
+
+
+          # cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
+          # sudo ldconfig
+          # ls -l /home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/libcudnn.so.8
 
       - name: Install Poetry
         run: |
@@ -71,8 +97,6 @@ jobs:
       - name: Run Pytest
         run: |
           export LD_LIBRARY_PATH=/home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib:$LD_LIBRARY_PATH
-          sudo ldconfig
-          ls -l /home/ubuntu/cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/libcudnn.so.8
 
 
           poetry run pytest --ignore=core/transform/tests/test_sentence_transformers.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+
+
+      - name: Set up CUDA
+        run: |
+          sudo apt-get install nvidia-cuda-toolkit nvidia-cuda-toolkit-gcc
+
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python -

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,8 +23,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
 
-      - name: Debugging with ssh
-        uses: lhotari/action-upterm@v1
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
         
 
       # Based on https://www.cloudbooklet.com/how-to-set-up-deep-learning-architecture-on-ubuntu-22-04/#install-cuda-toolkit-and-cu-dnn

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,9 +35,6 @@ jobs:
         run: |
           poetry install
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       # Based on https://medium.com/@mertguvencli/how-to-setup-nvidia-driver-cuda-toolkit-and-cudnn-in-ubuntu-20-4-ac5efedb4427
       - name: Install CUDA & cuDNN
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,6 +57,7 @@ jobs:
           sudo apt-get -y install libcudnn8-dev=8.5.0.*-1+cuda11.7
 
           # Install NCCL
+          # Based on: https://developer.nvidia.com/nccl/nccl-download (NCCL is not available for CUDA 11.7, so we pick 12.2)
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
           sudo dpkg -i cuda-keyring_1.0-1_all.deb
           sudo apt-get -y update


### PR DESCRIPTION
This PR adds CUDA installation to the Linux GHA runners executing our tests, so that the sentence transformers can pass tests without complaining about missing CUDA modules, even though they're not using them
