### PR TITLE
ci: Match prod branch name properly to trigger deploys

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set Environment
         id: env
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/prod" ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "environment=prod" >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
             echo "environment=staging" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Deploy didn't run on `dev` because our CI assumed the branch was called `prod` while it is called `main` -- this fixes it.