### PR TITLE
fix: Section in docs was copy pasted twice

### DIFF
--- a/docs/concepts/pipeline.mdx
+++ b/docs/concepts/pipeline.mdx
@@ -64,12 +64,6 @@ pipeline.pipe(
   Will print a progress bar if set to `True`
 </ParamField>
 
-**Parameters**
-
-<ParamField body="verbose" type="boolean" default="True">
-  Will print a progress bar if set to `True`
-</ParamField>
-
 ### pipe_all
 
 ```bash


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
- The `verbose` parameter in one of the pages was copy pasted twice

**Why**

**How**

**Tests**
