### PR TITLE
fix: upsert in opensearch connector

### DIFF
--- a/core/load/opensearch.py
+++ b/core/load/opensearch.py
@@ -54,16 +54,21 @@ class OpenSearchLoader(Loader):
         if metadata is not None:
             docs: List[Dict[str, Any]] = []
             for doc_id, embedding, meta in zip(ids, embeddings, metadata):
-                docs.append({"index": {"_index": index_name, "_id": doc_id}})
-                docs.append({field_name: embedding, **meta})
+                docs.append({"update": {"_index": index_name, "_id": doc_id}})
+                docs.append(
+                    {"doc": {field_name: embedding, **meta}, "doc_as_upsert": True}
+                )
 
         else:
             docs = []
             for doc_id, embedding in zip(ids, embeddings):
-                docs.append({"index": {"_index": index_name, "_id": doc_id}})
+                docs.append({"update": {"_index": index_name, "_id": doc_id}})
                 docs.append(
                     {
-                        field_name: embedding,
+                        "doc": {
+                            field_name: embedding,
+                        },
+                        "doc_as_upsert": True,
                     }
                 )
         self.opensearch.bulk(body=docs)


### PR DESCRIPTION
**Ticket(s) Closed**
N/A

**What**

The previous implementation of the OpenSearch Connector was indexing documents, but not properly upserting as the function name indicates. This change adds the intended behavior so the document is updated if exists, or created if it doesn't exist.

**Why**

That is the intended behavior of the `bulk_upsert_embeddings` function.

**How**

Using the `doc_as_upsert` option on the request, and setting the operation type to `update`.

**Tests**
