### PR TITLE
fix: Typo where weaviate_url was used as a dummy url in the Qdrant sink

### DIFF
--- a/docs/concepts/sink.mdx
+++ b/docs/concepts/sink.mdx
@@ -52,7 +52,7 @@ sink = Sink.Weaviate(
 ```bash
 sink = Sink.Qdrant(
     api_key="***",
-    url="weaviate_url"
+    url="qdrant_url"
 )
 ```
 


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
- Fixed small typo in documentation

**Why**

**How**

**Tests**
