### PR TITLE
feat: Allow users to upsert custom documents to an index

### DIFF
--- a/api/routers/index.py
+++ b/api/routers/index.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, BackgroundTasks, status
 from loguru import logger
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from api.config.kafka import KafkaConfig
 from api.config.opensearch import OpenSearchConfig
@@ -39,6 +39,11 @@ class SearchPayload(BaseModel):
     dsl: Dict[str, Any]
 
 
+class UpsertPayload(BaseModel):
+    index_name: str 
+    documents: List[Dict[str, Any]]
+    ids: List[Union[str, int]]
+
 class AddSourcePayload(BaseModel):
     index_name: str
     source_host: str
@@ -64,6 +69,21 @@ async def get_index(index_name: str) -> JSONResponse:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content=str(e),
+        )
+    
+@router.post("/{tag}/upsert", tags=[tag])
+async def upsert(payload: UpsertPayload):
+    try:
+        index = client.get_index(payload.index_name)
+        index.upsert(payload.documents, payload.ids)
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content=f"Documents upserted successfully",
+        )
+    except Exception as e:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=f"Failed to upsert documents: {e}",
         )
 
 

--- a/api/routers/index.py
+++ b/api/routers/index.py
@@ -40,9 +40,10 @@ class SearchPayload(BaseModel):
 
 
 class UpsertPayload(BaseModel):
-    index_name: str 
+    index_name: str
     documents: List[Dict[str, Any]]
     ids: List[Union[str, int]]
+
 
 class AddSourcePayload(BaseModel):
     index_name: str
@@ -70,10 +71,16 @@ async def get_index(index_name: str) -> JSONResponse:
             status_code=status.HTTP_400_BAD_REQUEST,
             content=str(e),
         )
-    
+
+
 @router.post("/{tag}/upsert", tags=[tag])
 async def upsert(payload: UpsertPayload):
     try:
+        if not len(payload.documents) == len(payload.ids):
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=f"Length of documents and ids arrays must be equal",
+            )
         index = client.get_index(payload.index_name)
         index.upsert(payload.documents, payload.ids)
         return JSONResponse(

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -79,6 +79,20 @@ index = client.create_index("my_index")
 index.add_source(database, table)
 ```
 
+## Add Additional Data (Optional)
+
+Data stored outside of Postgres can be added to an index as well.
+
+```bash
+documents = [{"key": "value"}]
+ids = [id1]
+
+index.upsert(
+  documents=documents,
+  ids=ids
+)
+```
+
 ## Execute a Search
 
 Inside our Python application, we are ready to write and execute our first search query.


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #97 

**What**
- Enables users to upsert custom documents to an index

**Why**
- if users have data that lives outside their Postgres table

**How**
Added an `upsert` function to the `Index` class:

```
index.upsert(
   documents=[{"key", "value"}]
   ids=["id"]
)
```


**Tests**
