### PR TITLE
feat: Allow user to define index field types

### DIFF
--- a/api/routers/index.py
+++ b/api/routers/index.py
@@ -158,7 +158,6 @@ async def add_source(payload: AddSourcePayload) -> JSONResponse:
             primary_keys = chunk.get("primary_keys")
 
             if rows and primary_keys:
-                print("upserting", rows)
                 index.upsert(documents=rows, ids=primary_keys)
 
         return JSONResponse(

--- a/api/routers/index.py
+++ b/api/routers/index.py
@@ -10,6 +10,7 @@ from api.config.opensearch import OpenSearchConfig
 from core.extract.postgres import PostgresExtractor, ConnectionError
 from core.kafka.consumer import KafkaConsumer
 from core.search.client import Client
+from core.search.index_mappings import FieldType
 
 tag = "index"
 
@@ -56,6 +57,12 @@ class AddSourcePayload(BaseModel):
     source_neural_columns: List[str] = []
     source_dbname: str = "postgres"
     source_schema_name: str = "public"
+
+
+class CreateFieldPayload(BaseModel):
+    index_name: str
+    field_name: str
+    field_type: str
 
 
 @router.get("/index/{index_name}", tags=[tag])
@@ -278,4 +285,29 @@ async def search_documents(payload: SearchPayload) -> JSONResponse:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content=f"Failed to search documents: {e}",
+        )
+
+
+@router.post(f"/{tag}/field/create", tags=[tag])
+async def create_field(payload: CreateFieldPayload) -> JSONResponse:
+    try:
+        field_types = [e.value for e in FieldType]
+        if payload.field_type not in field_types:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=f"Invalid field type: {payload.field_type}. Accepted values are {field_types}",
+            )
+
+        index = client.get_index(payload.index_name)
+        index.mappings.upsert(
+            properties={payload.field_name: {"type": payload.field_type}}
+        )
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content=f"Field {payload.field_name} created successfully",
+        )
+    except Exception as e:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=f"Failed to create field: {e}",
         )

--- a/clients/python/retakesearch/index.py
+++ b/clients/python/retakesearch/index.py
@@ -95,3 +95,17 @@ class Index:
             return exc.response.json()
         except Exception as exc:
             return str(exc)
+
+    def create_field(self, field_name: str, field_type: str) -> Any:
+        json = {
+            "index_name": self.index_name,
+            "field_name": field_name,
+            "field_type": field_type,
+        }
+
+        with httpx.Client(timeout=None) as http:
+            response = http.post(
+                f"{self.url}/index/field/create", headers=self.headers, json=json
+            )
+            if not response.status_code == 200:
+                raise Exception(response.text)

--- a/core/search/index.py
+++ b/core/search/index.py
@@ -6,7 +6,7 @@ from loguru import logger
 from opensearchpy import OpenSearch, helpers
 from typing import Dict, List, Optional, Any, Union, cast
 
-from core.search.index_mappings import IndexMappings
+from core.search.index_mappings import IndexMappings, FieldType
 from core.search.index_settings import IndexSettings
 from core.search.model_group import ModelGroup
 from core.search.model import Model
@@ -73,7 +73,7 @@ class Index:
         knn_vector_properties = []
 
         for prop, prop_data in properties.items():
-            if prop_data.get("type") == "knn_vector":
+            if prop_data.get("type") == FieldType.KNN_VECTOR.value:
                 knn_vector_properties.append(prop)
 
         return knn_vector_properties
@@ -199,10 +199,14 @@ class Index:
             self.mappings.upsert(
                 properties={
                     f"{field}{reserved_embedding_field_name_ending}": {
-                        "type": "knn_vector",
+                        "type": FieldType.KNN_VECTOR.value,
                         "dimension": default_model_dimensions,
                         "method": {"name": "hnsw", "engine": "lucene"},
                     }
                     for field in fields
                 }
             )
+
+    def set_field_types(self, field_types: Dict[str, str]) -> None:
+        properties = {key: {"type": value} for key, value in field_types.items()}
+        self.mappings.upsert(properties=properties)

--- a/core/search/index.py
+++ b/core/search/index.py
@@ -206,7 +206,3 @@ class Index:
                     for field in fields
                 }
             )
-
-    def set_field_types(self, field_types: Dict[str, str]) -> None:
-        properties = {key: {"type": value} for key, value in field_types.items()}
-        self.mappings.upsert(properties=properties)

--- a/core/search/index_mappings.py
+++ b/core/search/index_mappings.py
@@ -2,6 +2,7 @@ from enum import Enum
 from opensearchpy import OpenSearch
 from typing import Dict, Any
 
+
 class FieldType(Enum):
     # Core Data Types
     TEXT = "text"
@@ -50,6 +51,7 @@ class FieldType(Enum):
     # Join Data Types
     JOIN = "join"
 
+
 class IndexMappings:
     def __init__(self, name: str, client: OpenSearch):
         self.name = name
@@ -59,8 +61,6 @@ class IndexMappings:
         # We upsert one-by-one, so if a single property fails, it does not
         # affect the others
         for attribute, values in properties.items():
-            try:
-                body = {"properties": {attribute: values}}
-                self.client.indices.put_mapping(index=self.name, body=body)
-            except Exception as e:
-                print(f"Failed to upsert {attribute} with {values}: {e}")
+            body = {"properties": {attribute: values}}
+            print(body)
+            self.client.indices.put_mapping(index=self.name, body=body)

--- a/core/search/index_mappings.py
+++ b/core/search/index_mappings.py
@@ -1,6 +1,54 @@
+from enum import Enum
 from opensearchpy import OpenSearch
 from typing import Dict, Any
 
+class FieldType(Enum):
+    # Core Data Types
+    TEXT = "text"
+    KEYWORD = "keyword"
+    INTEGER = "integer"
+    LONG = "long"
+    SHORT = "short"
+    BYTE = "byte"
+    DOUBLE = "double"
+    FLOAT = "float"
+    HALF_FLOAT = "half_float"
+    SCALED_FLOAT = "scaled_float"
+    DATE = "date"
+    BOOLEAN = "boolean"
+    BINARY = "binary"
+
+    # Complex Data Types
+    OBJECT = "object"
+    NESTED = "nested"
+
+    # Geo Data Types
+    GEO_POINT = "geo_point"
+    GEO_SHAPE = "geo_shape"
+
+    # Specialized Data Types
+    IP = "ip"
+    COMPLETION = "completion"
+    TOKEN_COUNT = "token_count"
+    CUSTOM = "custom"
+    SEARCH_AS_YOU_TYPE = "search_as_you_type"
+    CONSTANT_KEYWORD = "constant_keyword"
+    DENSE_VECTOR = "dense_vector"
+    SPARSE_VECTOR = "sparse_vector"
+    KNN_VECTOR = "knn_vector"
+    RANK_FEATURE = "rank_feature"
+    RANK_FEATURES = "rank_features"
+    PERCOLATOR = "percolator"
+
+    # Range Data Types
+    INTEGER_RANGE = "integer_range"
+    FLOAT_RANGE = "float_range"
+    LONG_RANGE = "long_range"
+    DATE_RANGE = "date_range"
+    DOUBLE_RANGE = "double_range"
+
+    # Join Data Types
+    JOIN = "join"
 
 class IndexMappings:
     def __init__(self, name: str, client: OpenSearch):

--- a/core/search/index_mappings.py
+++ b/core/search/index_mappings.py
@@ -62,5 +62,4 @@ class IndexMappings:
         # affect the others
         for attribute, values in properties.items():
             body = {"properties": {attribute: values}}
-            print(body)
             self.client.indices.put_mapping(index=self.name, body=body)


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #113 

**What**
- Introduces `Index.create_field` which allows users to set field names and types

**Why**
- Useful for cases where dynamic field mapping leads to incorrect results

**How**
- Introduced a `FieldType` enum
- Created a new API endpoint

**Tests**
- Tested manually with Python client
