### PR TITLE
fix: Don't throw error if an empty index is searched

### DIFF
--- a/core/search/index.py
+++ b/core/search/index.py
@@ -67,14 +67,10 @@ class Index:
         return cast(Dict[str, Any], response)
 
     def _get_embedding_field_names(self) -> List[str]:
-        mappings = self.client.indices.get_mapping(index=self.name)[self.name][
+        properties = self.client.indices.get_mapping(index=self.name)[self.name][
             "mappings"
-        ]
+        ].get("properties", dict())
 
-        if not mappings:
-            return []
-
-        properties = mappings["properties"]
         knn_vector_properties = []
 
         for prop, prop_data in properties.items():

--- a/core/search/index.py
+++ b/core/search/index.py
@@ -67,9 +67,14 @@ class Index:
         return cast(Dict[str, Any], response)
 
     def _get_embedding_field_names(self) -> List[str]:
-        properties = self.client.indices.get_mapping(index=self.name)[self.name][
+        mappings = self.client.indices.get_mapping(index=self.name)[self.name][
             "mappings"
-        ]["properties"]
+        ]
+
+        if not mappings:
+            return []
+
+        properties = mappings["properties"]
         knn_vector_properties = []
 
         for prop, prop_data in properties.items():


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
- There was a bug where searching an empty index would throw an error

**Why**

**How**

**Tests**
