### PR TITLE
fix: Fix docker deploy

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          file: Dockerfile
+          file: ./Dockerfile
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
 
@@ -89,6 +89,6 @@ jobs:
         with:
           context: ./sync
           platforms: linux/amd64,linux/arm64
-          file: Dockerfile
+          file: ./sync/Dockerfile
           push: true
           tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
Seems like the GitHub Action uses absolute paths 