### PR TITLE
fix: Show better error in search() if field is not vectorized

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,3 @@
 ignore = E501, W503
 exclude = 
     submodules/*
-    

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,5 @@
 [flake8]
 ignore = E501, W503
+exclude = 
+    submodules/*
+    

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,3 @@
 [flake8]
 ignore = E501, W503
-exclude = 
-    submodules/*
+exclude = submodules/*


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
- Currently the user gets a pretty confusing error if they try to do a neural/semantic search over a non-vectorized field

**Why**

**How**

**Tests**
