### PR TITLE
fix: Allow users to specify `schema` in `Table`

### DIFF
--- a/clients/python/retakesearch/index.py
+++ b/clients/python/retakesearch/index.py
@@ -18,6 +18,7 @@ class Table:
         self,
         name: str,
         columns: List[str],
+        schema: str = "public",
         transform: Optional[Dict[str, Any]] = None,
         relationship: Optional[Dict[str, Any]] = None,
         children: Optional[List["Table"]] = None,
@@ -25,11 +26,16 @@ class Table:
         self.name = name
         self.columns = columns
         self.transform = transform
+        self.schema = schema
         self.relationship = relationship
         self.children = children
 
     def to_schema(self) -> Dict[str, Any]:
-        schema: Dict[str, Any] = {"table": self.name, "columns": self.columns}
+        schema: Dict[str, Any] = {
+            "table": self.name,
+            "columns": self.columns,
+            "schema": self.schema,
+        }
 
         if self.transform:
             schema["transform"] = self.transform

--- a/clients/typescript/src/lib/index.ts
+++ b/clients/typescript/src/lib/index.ts
@@ -4,6 +4,7 @@ import helpers from "opensearch-js"
 interface TableSchema {
   table: string
   columns: string[]
+  schema?: string
   transform?: { [key: string]: any }
   relationship?: { [key: string]: any }
   children?: TableSchema[]
@@ -36,6 +37,7 @@ class Database {
 class Table {
   table: string
   columns: string[]
+  schema?: string
   transform?: { [key: string]: any }
   relationship?: { [key: string]: any }
   children?: Table[]
@@ -43,6 +45,7 @@ class Table {
   constructor(args: TableSchema) {
     this.table = args.table
     this.columns = args.columns
+    this.schema = args.schema ?? "public"
     this.transform = args.transform
     this.relationship = args.relationship
 
@@ -54,6 +57,7 @@ class Table {
     const schema: TableSchema = {
       table: this.table,
       columns: this.columns,
+      schema: this.schema,
     }
 
     if (this.transform) schema.transform = this.transform

--- a/docs/python/table.mdx
+++ b/docs/python/table.mdx
@@ -12,6 +12,7 @@ from retakesearch import Table
 table = Table(
     name="table_name",
     columns=["questions", "answers"]
+    schema="public"
 )
 ```
 
@@ -23,7 +24,10 @@ table = Table(
 <ParamField body="columns" type="str" required>
   Primary key column name
 </ParamField>
-<ParamField body="children" type="Dict[str, Any]">
+<ParamField body="columns" type="str" default="public">
+  Table schema name
+</ParamField>
+<ParamField body="schema" type="Dict[str, Any]">
   Child tables. Should be specified only if you wish to combine multiple tables
   inside a single index. All child tables provided must be linked to the primary
   table with a foreign key. Follows the [pgsync

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -79,8 +79,7 @@ database = Database(
     dbname="***"
 )
 
-# Provide the table name, primary key, and columns you
-# wish to search over here
+# Provide the table name and columns you wish to search over here
 table = Table(
     name="faqs"
     columns=["questions", "answers"]
@@ -110,8 +109,7 @@ const database = new Database({
   port: 5432,
 });
 
-// Provide the table name, primary key, and columns you
-// wish to search over here
+// Provide the table name and columns you wish to search over here
 const columns = ["column_to_search"];
 const table = new Table({
   table: "table_name",

--- a/docs/typescript/table.mdx
+++ b/docs/typescript/table.mdx
@@ -12,23 +12,7 @@ import { Table } from "retake-search";
 const table = new Table({
   table: "table_name",
   columns: ["column1"],
-  // Optional
-  transform: {
-    rename: {
-      column1: "another_name",
-    },
-  },
-  // Optional
-  children: [
-    new Table({
-      table: "child_table",
-      columns: ["column2", "column3"],
-      relationship: {
-        variant: "object",
-        type: "one_to_one",
-      },
-    }),
-  ],
+  schema: "public",
 });
 ```
 
@@ -39,6 +23,9 @@ const table = new Table({
 </ParamField>
 <ParamField body="columns" type="str" required>
   Primary key column name
+</ParamField>
+<ParamField body="schema" type="str" default="public">
+  Table schema name
 </ParamField>
 <ParamField body="children" type="Dict[str, Any]">
   Child tables. Should be specified only if you wish to combine multiple tables


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #161 

**What**
- Creates a `schema` argument that defaults to `public` for `Table`

**Why**

**How**

**Tests**
