### PR TITLE
fix: Typo in Python client docs (#174)

### DIFF
--- a/docs/python/table.mdx
+++ b/docs/python/table.mdx
@@ -24,10 +24,10 @@ table = Table(
 <ParamField body="columns" type="str" required>
   Primary key column name
 </ParamField>
-<ParamField body="columns" type="str" default="public">
+<ParamField body="schema" type="str" default="public">
   Table schema name
 </ParamField>
-<ParamField body="schema" type="Dict[str, Any]">
+<ParamField body="children" type="Dict[str, Any]">
   Child tables. Should be specified only if you wish to combine multiple tables
   inside a single index. All child tables provided must be linked to the primary
   table with a foreign key. Follows the [pgsync


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**

**Why**

**How**

**Tests**
