### PR TITLE
ci: Upgrade version to new tag version for npm

### DIFF
--- a/.github/workflows/publish-retake-to-npm.yml
+++ b/.github/workflows/publish-retake-to-npm.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
 
+      - name: Update Version
+        working-directory: clients/typescript
+        run: jq ".version = \"${GITHUB_REF#refs/tags/v}\"" package.json > "tmp.json" && mv "tmp.json" "package.json"
+
       - name: Install Dependencies
         working-directory: clients/typescript
         run: npm install && npm ci

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "retake-search",
-  "license": "Elastic License 2.0",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
@@ -45,6 +46,5 @@
   "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
-  },
-  "version": "1.0.11"
+  }
 }

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -30,7 +30,7 @@
     "../../clients/typescript": {
       "name": "retake-search",
       "version": "1.0.10",
-      "license": "Elastic License 2.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "ky": "^0.33.3",
         "opensearch-js": "github:getretake/opensearch-js"


### PR DESCRIPTION
My deploy to NPM uses the new workflow with the `tag` approach which I want to move PyPi to eventually, and I had forgotten to make it increment with the new tag version. This should do it.