### PR TITLE
feat: Add more sections to How to Search documentation

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -57,6 +57,9 @@
         "search/filtering",
         "search/aggregation",
         "search/pagination",
+        "search/highlighting",
+        "search/boosting",
+        "search/object",
         "search/custom"
       ]
     },

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -97,6 +97,6 @@
   },
   "backgroundImage": "/background.png",
   "integrations": {
-    "intercom": "k8wp5os9"
+    "intercom": "gec3yw1w"
   }
 }

--- a/docs/search/boosting.mdx
+++ b/docs/search/boosting.mdx
@@ -1,0 +1,42 @@
+---
+title: Boosting
+---
+
+## Basic Usage
+
+Boosting is useful for cases where you want to demote certain results without excluding them. A boosting query
+achieves this by returning results that match a positive query. Among these results, the ones that also match a
+negative query are scored lower.
+
+The below example returns results where `name` matches "True Crime," but the scores of results with `description` fields containing
+"New York" are multiplied by `0.5`:
+
+<CodeGroup>
+
+```python Python
+from retakesearch import Q
+
+positive_query = Q("match", name="True Crime")
+negative_query = Q("match", description="New York")
+
+query = Search().query(
+    Q(
+        "boosting",
+        positive=positive_query,
+        negative=negative_query,
+        negative_boost=0.5
+    )
+)
+```
+
+```typescript Typescript
+import { boostingQuery, matchQuery } from "retake-search/helpers";
+
+const query = Search().boostingQuery(
+  matchQuery("name", "True Crime"), // Positive query
+  matchQuery("description", "New York"), // Negative query
+  0.5 // Negative boost
+);
+```
+
+</CodeGroup>

--- a/docs/search/highlighting.mdx
+++ b/docs/search/highlighting.mdx
@@ -1,0 +1,33 @@
+---
+title: Highlighting
+---
+
+## Basic Usage
+
+Highlighting is used in conjunction with text-based queries to emphasize query matches within the
+search result.
+
+<CodeGroup>
+
+```python Python
+# Highlights matches for the name field
+Search().highlight("name")
+
+# Highlights matches for the name and description fields and specifies the
+# highlighted fragment size
+Search().highlight("name", "description", fragment_size=50)
+```
+
+```typescript Typescript
+// Highlights matches for the name field
+Search().highlight().fields(["name"]);
+
+// Highlights matches for the name and description fields and specifies the
+// highlighted fragment size
+Search().highlight().fields(["name", "description"]).fragmentSize(50);
+```
+
+</CodeGroup>
+
+A list of all highlighting options can be found
+[here](https://opensearch.org/docs/2.2/opensearch/search/highlight/#highlighting-options).

--- a/docs/search/object.mdx
+++ b/docs/search/object.mdx
@@ -1,0 +1,77 @@
+---
+title: Object Search
+---
+
+## Single Object
+
+Suppose your field is a JSON object:
+
+```json
+{
+  "character": {
+    "name": "Spongebob",
+    "role": "protagonist"
+  }
+}
+```
+
+To query over a sub-field of that JSON object, first ensure that the field has type `object`. This can be done with
+[`Index.create_field`](/python/index#create_field) or by providing a [`transform` property in `Table`](/python/table).
+
+Next, use the `__` notation to dig into the field object:
+
+<CodeGroup>
+
+```python Python
+Search().query("match", character__name="Spongebob")
+```
+
+```typescript Typescript
+import { matchQuery } from "retake-search/helpers";
+
+Search().query(matchQuery("character.name", "Spongebob"));
+```
+
+</CodeGroup>
+
+## List of Objects
+
+Suppose your field is a list of JSON objects:
+
+```json
+{
+  "characters": [
+    {
+      "name": "Spongebob",
+      "role": "protagonist"
+    },
+    {
+      "name": "Plankton",
+      "role": "antagonist"
+    }
+  ]
+}
+```
+
+To query over sub-fields of these JSON objects, first ensure that the field has type `nested`.
+
+Next, use the `nested` and `Q` operators:
+
+<CodeGroup>
+
+```python Python
+from retakesearch import Q
+
+Search().query("nested", path="characters", query=Q("match", name="Spongebob"))
+```
+
+```typescript Typescript
+import { nestedQuery, matchQuery } from "retake-search/helpers";
+
+Search()
+  .nestedQuery()
+  .path("characters")
+  .query(matchQuery("characters.name", "Spongebob"));
+```
+
+</CodeGroup>

--- a/docs/search/overview.mdx
+++ b/docs/search/overview.mdx
@@ -7,10 +7,20 @@ title: Overview
   up Retake](/quickstart).
 </Info>
 
-To execute a search query, you must use the `Index.search` function and
-pass in the search query, written using the `Search` high-level Python client.
+The `Search` class is used to construct search requests. Behind the scenes, Retake translates `Search` requests
+to OpenSearch's query language (DSL). `Search` is designed with three main objectives:
+
+1. **Composability**: Complex requests are composed by mixing and matching various components — queries,
+   boolean logic, filters, aggregation, etc. — with one another.
+
+2. **Readability**: Requests are constructed as a logical pipeline of transformations.
+
+3. **Full OpenSearch Functionality**: `Search` supports the entire OpenSearch DSL, which is identical to
+   the ElasticSearch DSL except in rare cases. Most queries, no matter how complex, are possible.
 
 ## Basic Usage
+
+The `Index.search` function is responsible for executing queries constructed with `Search`.
 
 This example performs a keyword search for all rows in the Postgres table `faqs` where
 the column `question` matches the phrase "Who Am I?".
@@ -82,6 +92,54 @@ const query = Search()
 ```
 
 </CodeGroup>
+
+## Field Types
+
+Index fields have types, which are used to tell the search layer how to index the field and what kinds of search operations
+are allowed on the field. If no field type is set when data is uploaded, Retake will infer and dynamically assign a field
+type. But in many cases, developers will want to specify a field type themselves.
+
+### Setting a Field Type
+
+The `transform` property of the `Table` class has functionality to specify what field type each column should map to:
+
+<CodeGroup>
+
+```python Python
+table = Table(
+    name="tv_shows",
+    columns=["description", "rating"],
+    transform={
+      "mapping": {
+        "description": "text",
+        "rating": "double"
+      }
+    }
+)
+```
+
+</CodeGroup>
+
+`Index.create_field`also enables developers to create a field with a certain type. Note that once a field is created, its
+type cannot be changed.
+
+<CodeGroup>
+
+```python Python
+index.create_field("description", "text")
+```
+
+</CodeGroup>
+
+### Choosing a Field Type
+
+`text` and `keyword` are two common field types . Text fields are typically used for longer pieces of text, whereas
+keyword fields are typically used for individual words or phrases for the purpose of exact matching or filtering. Text fields
+should be queried with the `match` operator, whereas keyword fields are queried with the `term` operator.
+
+In addition, Retake supports a [wide variety of other field types](https://github.com/getretake/retake/blob/fb43fd2eb09f54218907876a88452e7e9974cdd1/core/search/index_mappings.py#L4).
+
+## Helpful Resources
 
 The following sections will cover the specifics of how to write different types of queries. Please note
 that this is guide is non-exhaustive, and that many more features of the `Search` client can be found


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #181 

**What**
Adds more important sections to the How to Search documentation:
- Field Types
- Highlighting
- Object Queries
- Boosting

**Why**

**How**

**Tests**
