### PR TITLE
ci: Auth to docker to avoid rate limits

### DIFF
--- a/.github/workflows/publish-retake-to-dockerhub.yml
+++ b/.github/workflows/publish-retake-to-dockerhub.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v3
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
       - name: Configure Docker Hub Metadata
         id: metadata
         uses: docker/metadata-action@v4
@@ -37,17 +43,11 @@ jobs:
             type=semver,pattern={{version}}
 
       # Add support for more platforms with QEMU (necessary for arm64-compatible images)
-      - name: Set up QEMU
+      - name: Set up Docker QEMU
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Build and Push Docker Image to Docker Hub
         uses: docker/build-push-action@v4
@@ -66,6 +66,12 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v3
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
       - name: Configure Docker Hub Metadata
         id: metadata
         uses: docker/metadata-action@v4
@@ -76,17 +82,11 @@ jobs:
             type=semver,pattern={{version}}
 
       # Add support for more platforms with QEMU (necessary for arm64-compatible images)
-      - name: Set up QEMU
+      - name: Set up Docker QEMU
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Build and Push Docker Image to Docker Hub
         uses: docker/build-push-action@v4

--- a/.github/workflows/test-retake.yml
+++ b/.github/workflows/test-retake.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v3
 
+      # To avoid rate limits when pulling Docker images in the integration tests
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
       - name: Set up Python Environment
         uses: actions/setup-python@v3
 


### PR DESCRIPTION
We weren't auth-ed when running `pytest` in CI, which is why we were getting rate limits
