### PR TITLE
feat: add SSL for docker compose deploy

### DIFF
--- a/api/config/opensearch.py
+++ b/api/config/opensearch.py
@@ -15,7 +15,7 @@ if not (
     and opensearch_password
     and opensearch_use_tls
 ):
-    raise EnvironmentError("No environment variables found")
+    raise EnvironmentError("No opensearch environment variables found")
 
 
 class OpenSearchConfig(Config):

--- a/api/config/pgsync.py
+++ b/api/config/pgsync.py
@@ -3,9 +3,8 @@ from api.config.base import Config
 
 pgsync_host = os.environ.get("PGSYNC_HOST")
 pgsync_port = os.environ.get("PGSYNC_PORT")
-pgsync_use_tls = os.environ.get("PGSYNC_SSL_ENABLED")
 
-if not (pgsync_host and pgsync_port and pgsync_use_tls):
+if not (pgsync_host and pgsync_port):
     raise EnvironmentError("No pgsync environment variables found")
 
 
@@ -14,9 +13,5 @@ class PgSyncConfig(Config):
     def url(self) -> str:
         host = self.get_property("PGSYNC_HOST")
         port = self.get_property("PGSYNC_PORT")
-        pgsync_use_tls = self.get_property("PGSYNC_SSL_ENABLED")
-        use_tls = pgsync_use_tls == "True" or pgsync_use_tls == "true"
-        if use_tls:
-            return f"https://{host}{port}"
 
         return f"http://{host}:{port}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [ $# -eq 0 ]; then
+    # If no argument is provided, set domain to "localhost"
+    domain="localhost"
+else
+    domain=$1
+fi
+
+# Write Caddyfile
+cat << EOF > Caddyfile
+$domain {
+    handle_path /retake/* {
+        reverse_proxy api:8000
+    }
+}
+EOF
+
+# Start cluster
+docker compose up -d

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,21 +1,51 @@
 #!/bin/bash
 set -e
 
-if [ $# -eq 0 ]; then
-    echo "Please provide a domain as a positional argument."
+if [ -z "$1" ]; then
+    echo "Domain not provided."
+    echo "Usage: $0 <domain>"
+    echo "Please ensure that the server running this script has a DNS A record pointing to it from the provided domain."
     exit 1
 fi
 
 DOMAIN=$1
 
+if [ ! -z "$2" ]; then
+    echo "Using 'dev' branch as default."
+    GIT_BRANCH="dev"
+else
+    GIT_BRANCH=$2
+fi
+
+# Clone repo
+echo "Cloning Retake..."
+git clone https://github.com/getretake/retake.git
+cd retake
+git checkout "$GIT_BRANCH"
+
 # Write Caddyfile
 cat << EOF > Caddyfile
 $DOMAIN {
-    handle_path /retake/* {
-        reverse_proxy api:8000
-    }
+    reverse_proxy api:8000
 }
 EOF
 
-# Start cluster
-docker compose up -d
+# Install Docker and Docker Compose
+echo "Installing Docker..."
+sudo apt-get install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Enable non-root docker
+sudo usermod -aG docker "${USER}" || true
+
+# Start stack
+echo "Starting docker compose..."
+sudo -E docker compose up -d

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,15 +2,15 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    # If no argument is provided, set domain to "localhost"
-    domain="localhost"
-else
-    domain=$1
+    echo "Please provide a domain as a positional argument."
+    exit 1
 fi
+
+DOMAIN=$1
 
 # Write Caddyfile
 cat << EOF > Caddyfile
-$domain {
+$DOMAIN {
     handle_path /retake/* {
         reverse_proxy api:8000
     }

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,6 +36,8 @@ sudo apt-get install -y ca-certificates curl gnupg
 sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+# shellcheck source=/dev/null
 echo \
   "deb [arch=\"$(dpkg --print-architecture)\" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
   \"$(. /etc/os-release && echo "$VERSION_CODENAME")\" stable" | \

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -Eeuo pipefail
 
 if [ -z "$1" ]; then
     echo "Domain not provided."
@@ -10,7 +10,7 @@ fi
 
 DOMAIN=$1
 
-if [ ! -z "$2" ]; then
+if [ -n "$2" ]; then
     echo "Using 'dev' branch as default."
     GIT_BRANCH="dev"
 else
@@ -37,8 +37,8 @@ sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  "deb [arch=\"$(dpkg --print-architecture)\" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  \"$(. /etc/os-release && echo "$VERSION_CODENAME")\" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt update
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,8 @@ services:
     extends:
       file: ./docker-compose.yml
       service: core
+    ports:
+      - 9200:9200
 
   api:
     build:
@@ -34,6 +36,8 @@ services:
     extends:
       file: ./docker-compose.yml
       service: redis
+    ports:
+      - 6379:6379
 
   pgsync:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,7 @@ version: "3"
 
 services:
   core:
-    image: public.ecr.aws/opensearchproject/opensearch:latest
-    ports:
-      - 9200:9200
-      - 9600:9600
+    image: public.ecr.aws/opensearchproject/opensearch:2.9.0
     environment:
       - discovery.type=single-node
       - plugins.security.disabled=false
@@ -16,24 +13,33 @@ services:
     image: retake/retakesearch:latest
     depends_on:
       - core
-    ports:
-      - 8000:8000
+    command: uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload
     environment:
       API_KEY: retake-test-key
       OPENSEARCH_HOST: core
       OPENSEARCH_PORT: 9200
       OPENSEARCH_USER: admin
       OPENSEARCH_PASSWORD: admin
-      OPENSEARCH_USE_TLS: False
+      OPENSEARCH_USE_TLS: True
       PGSYNC_HOST: pgsync
       PGSYNC_PORT: 7433
-      PGSYNC_SSL_ENABLED: False
     volumes:
       - .:/app
 
   redis:
-    image: redis:latest
-    command: redis-server --requirepass redis
+    image: redis:7.0.12-alpine
+    command: redis-server
+
+  caddy:
+    image: caddy:2.7.2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
 
   pgsync:
     image: retake/retakesync:latest
@@ -62,8 +68,9 @@ services:
       ELASTICSEARCH_VERIFY_CERTS: False
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      REDIS_AUTH: redis
       ELASTICSEARCH: false
       OPENSEARCH: true
-    volumes:
-      - .:/app
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     image: retake/retakesearch:latest
     depends_on:
       - core
-    command: uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload
     environment:
       API_KEY: retake-test-key
       OPENSEARCH_HOST: core

--- a/sync/sidecar.py
+++ b/sync/sidecar.py
@@ -50,7 +50,6 @@ async def sync(request: Request) -> Response:
             "ELASTICSEARCH_VERIFY_CERTS": os.getenv("ELASTICSEARCH_VERIFY_CERTS"),
             "REDIS_HOST": os.getenv("REDIS_HOST"),
             "REDIS_PORT": os.getenv("REDIS_PORT"),
-            "REDIS_AUTH": os.getenv("REDIS_AUTH"),
             "ELASTICSEARCH": os.getenv("ELASTICSEARCH"),
             "OPENSEARCH": os.getenv("OPENSEARCH"),
         }


### PR DESCRIPTION
**Ticket(s) Closed**

- Possibly Closes #108 

**What**
Modify the current docker compose deploy to use SSL termination using a reverse proxy.

**Why**
The current setup is insecure, it exposes ports to HTTP traffic. This PR proposes closing all traffic to the docker containers and allowing access only through the reverse proxy server, which is secured with SSL. Internal communication will be kept as HTTP since the network is not exposed. This might change at a later time if we decide we want to add additional security.

**How**
The approach consists of:
1. A deploy script which writes the configuration file for Caddy using the provided domain.
2. Caddy server, which automatically redirects all HTTPS requests to the Retake API server.

**Tests**
