### PR TITLE
feat: Add non-intrusive, opt-out telemetry via PostHog

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -11,10 +11,15 @@ from .routers import index
 from .routers import client
 from .routers import base
 
+
+
+
+
 # TODO: Add SSL and remove this
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 API_KEY = os.getenv("API_KEY", "")
+TELEMETRY = os.getenv("TELEMETRRY", "enabled")
 
 
 class APIKeyValidator:

--- a/api/app.py
+++ b/api/app.py
@@ -6,20 +6,20 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 from typing import Callable, Optional, Any
+from posthog import Posthog
 
 from .routers import index
 from .routers import client
 from .routers import base
 
-
-
-
-
 # TODO: Add SSL and remove this
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 API_KEY = os.getenv("API_KEY", "")
-TELEMETRY = os.getenv("TELEMETRRY", "enabled")
+POSTHOG_API_KEY = os.getenv("POSTHOG_API_KEY")
+TELEMETRY = os.getenv("TELEMETRY", "enabled")
+
+posthog = Posthog(POSTHOG_API_KEY, host='https://app.posthog.com')
 
 
 class APIKeyValidator:
@@ -76,3 +76,6 @@ app.add_middleware(AuthMiddleware, api_key_validator=APIKeyValidator(API_KEY))
 app.include_router(index.router)
 app.include_router(base.router)
 app.include_router(client.router)
+
+posthog.capture('distinct_id_of_the_user', 
+    'A user deployed Retake')

--- a/api/app.py
+++ b/api/app.py
@@ -19,7 +19,7 @@ API_KEY = os.getenv("API_KEY", "")
 POSTHOG_API_KEY = os.getenv("POSTHOG_API_KEY")
 TELEMETRY = os.getenv("TELEMETRY", "enabled")
 
-posthog = Posthog(POSTHOG_API_KEY, host='https://app.posthog.com')
+posthog = Posthog(POSTHOG_API_KEY, host="https://app.posthog.com")
 
 
 class APIKeyValidator:
@@ -77,5 +77,5 @@ app.include_router(index.router)
 app.include_router(base.router)
 app.include_router(client.router)
 
-posthog.capture('distinct_id_of_the_user', 
-    'A user deployed Retake')
+if TELEMETRY != "disabled":
+    posthog.capture("distinct_id_of_the_user", "A user deployed Retake")

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@
 set -Eeuo pipefail
 
 # Make sure the console is huuuge
-if test $(tput cols) -ge 64; then
+if test "$(tput cols)" -ge 64; then
   # Make it green!
   echo -e "\033[32m"
   echo -e "______ _____ _____ ___   _   __ _____ "
@@ -35,12 +35,12 @@ else
     echo ""
 fi
 
-if ! [ -z "${RETAKE_APP_TAG:-}" ]; then
+if ! [ -n "${RETAKE_APP_TAG:-}" ]; then
     export RETAKE_APP_TAG=$RETAKE_APP_TAG
 else
     echo "What version of Retake would you like to install? Browse available versions here: https://hub.docker.com/r/retake/retakesearch/tags"
     read -p "Please enter a valid tag (i.e.: vX.Y.Z) or press Enter to default to 'latest': " RETAKE_APP_TAG
-    if [ -z "$RETAKE_APP_TAG" ]; then
+    if [ -n "$RETAKE_APP_TAG" ]; then
         export RETAKE_APP_TAG="${RETAKE_APP_TAG:-latest}"
     else
         export RETAKE_APP_TAG=$RETAKE_APP_TAG
@@ -49,13 +49,13 @@ else
 fi
 echo ""
 
-if ! [ -z "${DOMAIN:-}" ]; then
+if ! [ -n "${DOMAIN:-}" ]; then
     export DOMAIN=$DOMAIN
 else
     echo "Let's get the exact domain Retake will be installed on. This will be used for TLS 🔐."
     echo "Make sure that you have a Host A DNS record pointing to this instance!"
     read -p "Please enter your configured domain (i.e.: search.getretake.com): " DOMAIN
-    if [ -z "$DOMAIN" ]; then
+    if [ -n "$DOMAIN" ]; then
         echo "Domain not provided. This step is mandatory, exiting..."
         exit 1
     fi
@@ -79,7 +79,7 @@ sudo -E docker-compose -f docker-compose.yml stop &> /dev/null || true
 # Retake uses basic telemetry to monitor usage (number of deployments, and number
 # of search queries per deployment). If you prefer not to be included in our telemetry,
 # simply set TELEMETRY=disabled in your .env file.
-if ! [ -z "${TELEMETRY:-}" ]; then
+if ! [ -n "${TELEMETRY:-}" ]; then
     if [ "${TELEMETRY}" == "disabled" ]; then
         echo "Telemetry successfully disabled -- Retake will not get any usage data from your deployment."
         echo "Retake has very light telemetry (i.e.: is your deploy running, and how many search queries are you running?)."
@@ -110,7 +110,7 @@ else
     releaseTag="${RETAKE_APP_TAG/release-/""}"
     git fetch --tags
     echo "Checking out Retake release: $releaseTag"
-    git checkout $releaseTag
+    git checkout "$releaseTag"
 fi
 
 # Write Caddyfile

--- a/deploy.sh
+++ b/deploy.sh
@@ -80,7 +80,7 @@ sudo -E docker-compose -f docker-compose.yml stop &> /dev/null || true
 # of search queries per deployment). If you prefer not to be included in our telemetry,
 # simply set TELEMETRY=disabled in your .env file.
 if ! [ -z "${TELEMETRY:-}" ]; then
-    if [ "${TELEMETRY}" == "disabled"]; then
+    if [ "${TELEMETRY}" == "disabled" ]; then
         echo "Telemetry successfully disabled -- Retake will not get any usage data from your deployment."
         echo "Retake has very light telemetry (i.e.: is your deploy running, and how many search queries are you running?)."
         echo "We do this to get a sense of how much usage Retake is getting, which helps us prioritize features and support."

--- a/deploy.sh
+++ b/deploy.sh
@@ -116,7 +116,7 @@ fi
 
 # Write Caddyfile
 cat << EOF > Caddyfile
-$DOMAIN {
+$DOMAIN :80 :443 {
     reverse_proxy api:8000
 }
 EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# This script is inspired from PostHog and Airbyte, thanks to them for the inspiration!
+
 set -Eeuo pipefail
 
 # Make sure the console is huuuge

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,13 +29,14 @@ echo ""
 
 if [ -f ".env" ]; then
     echo "Environment file .env found, sourcing it."
+    # shellcheck disable=SC1091
     source .env
 else
     echo "Environment file .env not found. You will be prompted for the following environment variables: RETAKE_APP_TAG, DOMAIN"
     echo ""
 fi
 
-if ! [ -z "${RETAKE_APP_TAG:-}" ]; then
+if [ -n "${RETAKE_APP_TAG:-}" ]; then
     export RETAKE_APP_TAG=$RETAKE_APP_TAG
 else
     echo "What version of Retake would you like to install? Browse available versions here: https://hub.docker.com/r/retake/retakesearch/tags"
@@ -49,12 +50,12 @@ else
 fi
 echo ""
 
-if ! [ -z "${DOMAIN:-}" ]; then
+if [ -n "${DOMAIN:-}" ]; then
     export DOMAIN=$DOMAIN
 else
     echo "Let's get the exact domain Retake will be installed on. This will be used for TLS 🔐."
     echo "Make sure that you have a Host A DNS record pointing to this instance!"
-    read -p "Please enter your configured domain (i.e.: search.getretake.com): " DOMAIN
+    read -rp "Please enter your configured domain (i.e.: search.getretake.com): " DOMAIN
     if [ -n "$DOMAIN" ]; then
         echo "Domain not provided. This step is mandatory, exiting..."
         exit 1
@@ -79,7 +80,7 @@ sudo -E docker-compose -f docker-compose.yml stop &> /dev/null || true
 # Retake uses basic telemetry to monitor usage (number of deployments, and number
 # of search queries per deployment). If you prefer not to be included in our telemetry,
 # simply set TELEMETRY=disabled in your .env file.
-if ! [ -z "${TELEMETRY:-}" ]; then
+if [ -n "${TELEMETRY:-}" ]; then
     if [ "${TELEMETRY}" == "disabled" ]; then
         echo "Telemetry successfully disabled -- Retake will not get any usage data from your deployment."
         echo "Retake has very light telemetry (i.e.: is your deploy running, and how many search queries are you running?)."

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,27 +1,114 @@
 #!/bin/bash
+
 set -Eeuo pipefail
 
-if [ -z "$1" ]; then
-    echo "Domain not provided."
-    echo "Usage: $0 <domain>"
-    echo "Please ensure that the server running this script has a DNS A record pointing to it from the provided domain."
-    exit 1
+# Make sure the console is huuuge
+if test $(tput cols) -ge 64; then
+  # Make it green!
+  echo -e "\033[32m"
+  echo -e "______ _____ _____ ___   _   __ _____ "
+  echo -e "| ___ \  ___|_   _/ _ \ | | / /|  ___|"
+  echo -e "| |_/ / |__   | |/ /_\ \| |/ / | |__  "
+  echo -e "|    /|  __|  | ||  _  ||    \ |  __| "
+  echo -e "| |\ \| |___  | || | | || |\  \| |___ "
+  echo -e "\_| \_\____/  \_/\_| |_/\_| \_/\____/ "
+  echo -e "                      Universal Search"
+  # Make it less green
+  echo -e "\033[0m"
+  sleep 1
 fi
 
-DOMAIN=$1
+# Talk to the user
+echo "Welcome to the single instance Retake installer!"
+echo ""
+echo "Power user or aspiring power user?"
+echo "Check out our docs on deploying Retake! https://docs.getretake.com/deployment/local"
+echo ""
 
-if [ -n "$2" ]; then
-    echo "Using 'dev' branch as default."
-    GIT_BRANCH="dev"
+if [ -f ".env" ]; then
+    echo "Environment file .env found, sourcing it."
+    source .env
 else
-    GIT_BRANCH=$2
+    echo "Environment file .env not found. You will be prompted for the following environment variables: RETAKE_APP_TAG, DOMAIN"
+    echo ""
 fi
 
-# Clone repo
+if ! [ -z "${RETAKE_APP_TAG:-}" ]; then
+    export RETAKE_APP_TAG=$RETAKE_APP_TAG
+else
+    echo "What version of Retake would you like to install? Browse available versions here: https://hub.docker.com/r/retake/retakesearch/tags"
+    read -p "Please enter a valid tag (i.e.: vX.Y.Z) or press Enter to default to 'latest': " RETAKE_APP_TAG
+    if [ -z "$RETAKE_APP_TAG" ]; then
+        export RETAKE_APP_TAG="${RETAKE_APP_TAG:-latest}"
+    else
+        export RETAKE_APP_TAG=$RETAKE_APP_TAG
+    fi
+    echo "Using tag: $RETAKE_APP_TAG"
+fi
+echo ""
+
+if ! [ -z "${DOMAIN:-}" ]; then
+    export DOMAIN=$DOMAIN
+else
+    echo "Let's get the exact domain Retake will be installed on. This will be used for TLS 🔐."
+    echo "Make sure that you have a Host A DNS record pointing to this instance!"
+    read -p "Please enter your configured domain (i.e.: search.getretake.com): " DOMAIN
+    if [ -z "$DOMAIN" ]; then
+        echo "Domain not provided. This step is mandatory, exiting..."
+        exit 1
+    fi
+fi
+export DOMAIN=$DOMAIN
+echo ""
+
+echo "Ok! we'll set up certs for https://$DOMAIN 🎉"
+echo ""
+echo "We will need sudo access so the next question is for you to give us superuser access"
+echo "Please enter your sudo password now:"
+sudo echo ""
+echo "Thanks! 🙏"
+echo ""
+echo "Ok! We'll take it from here 🚀"
+echo ""
+
+echo "Making sure any stack that might exist is stopped..."
+sudo -E docker-compose -f docker-compose.yml stop &> /dev/null || true
+
+# Retake uses basic telemetry to monitor usage (number of deployments, and number
+# of search queries per deployment). If you prefer not to be included in our telemetry,
+# simply set TELEMETRY=disabled in your .env file.
+if ! [ -z "${TELEMETRY:-}" ]; then
+    if [ "${TELEMETRY}" == "disabled"] then;
+        echo "Telemetry successfully disabled -- Retake will not get any usage data from your deployment."
+        echo "Retake has very light telemetry (i.e.: is your deploy running, and how many search queries are you running?)."
+        echo "We do this to get a sense of how much usage Retake is getting, which helps us prioritize features and support."
+        echo "We never collect actual search queries, or PII. If this telemetry is okay with you, please consider re-enabling it."
+        echo "Much love <3!"
+else
+    # Temporary, until we get onboarded onto PostHog
+    curl -X POST -H 'Content-type: application/json' --data '{"text":"A new user deployed our docker-compose stack!"}' https://hooks.slack.com/services/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
+    export TELEMETRY=$TELEMETRY
+fi
+
+echo "Grabbing latest APT caches..."
+sudo apt update
+
 echo "Cloning Retake..."
-git clone https://github.com/getretake/retake.git
+sudo apt install -y git
+# try to clone - if folder is already there pull latest for that branch
+git clone https://github.com/getretake/retake.git &> /dev/null || true
 cd retake
-git checkout "$GIT_BRANCH"
+
+if [[ "$RETAKE_APP_TAG" = "latest" ]]
+then
+    echo "Pulling latest from current branch: $(git branch --show-current)"
+    git pull
+else
+    releaseTag="${RETAKE_APP_TAG/release-/""}"
+    git fetch --tags
+    echo "Checking out Retake release: $releaseTag"
+    git checkout $releaseTag
+fi
 
 # Write Caddyfile
 cat << EOF > Caddyfile
@@ -32,7 +119,7 @@ EOF
 
 # Install Docker and Docker Compose
 echo "Installing Docker..."
-sudo apt-get install -y ca-certificates curl gnupg
+sudo apt install -y ca-certificates curl gnupg
 sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
@@ -43,11 +130,25 @@ echo \
   \"$(. /etc/os-release && echo "$VERSION_CODENAME")\" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt update
-sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo apt -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Enable non-root docker
 sudo usermod -aG docker "${USER}" || true
 
 # Start stack
+echo ""
 echo "Starting docker compose..."
 sudo -E docker compose up -d
+
+echo ""
+echo "⏳ Waiting for Retake to be ready (this will take a few minutes)"
+bash -c 'while [[ "$(curl -s -o /dev/null -H "Authorization: Bearer retake-test-key" -w ''%{http_code}'' localhost:8000)" != "200" ]]; do sleep 5; done'
+echo "⌛️ Retake looks up at https://${DOMAIN}!"
+echo ""
+echo "🎉🎉🎉 Done! 🎉🎉🎉"
+echo ""
+echo "To stop the stack, run 'docker compose down'"
+echo "To start the stack again, run 'docker compose up'"
+echo "If you have any issues at all delete everything in this directory and run the curl command again"
+echo "Happy searching!"
+echo ""

--- a/deploy.sh
+++ b/deploy.sh
@@ -78,12 +78,13 @@ sudo -E docker-compose -f docker-compose.yml stop &> /dev/null || true
 # of search queries per deployment). If you prefer not to be included in our telemetry,
 # simply set TELEMETRY=disabled in your .env file.
 if ! [ -z "${TELEMETRY:-}" ]; then
-    if [ "${TELEMETRY}" == "disabled"] then;
+    if [ "${TELEMETRY}" == "disabled"]; then
         echo "Telemetry successfully disabled -- Retake will not get any usage data from your deployment."
         echo "Retake has very light telemetry (i.e.: is your deploy running, and how many search queries are you running?)."
         echo "We do this to get a sense of how much usage Retake is getting, which helps us prioritize features and support."
         echo "We never collect actual search queries, or PII. If this telemetry is okay with you, please consider re-enabling it."
         echo "Much love <3!"
+    fi
 else
     # Temporary, until we get onboarded onto PostHog
     curl -X POST -H 'Content-type: application/json' --data '{"text":"A new user deployed our docker-compose stack!"}' https://hooks.slack.com/services/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

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,11 +35,11 @@ else
     echo ""
 fi
 
-if ! [ -n "${RETAKE_APP_TAG:-}" ]; then
+if ! [ -z "${RETAKE_APP_TAG:-}" ]; then
     export RETAKE_APP_TAG=$RETAKE_APP_TAG
 else
     echo "What version of Retake would you like to install? Browse available versions here: https://hub.docker.com/r/retake/retakesearch/tags"
-    read -p "Please enter a valid tag (i.e.: vX.Y.Z) or press Enter to default to 'latest': " RETAKE_APP_TAG
+    read -rp "Please enter a valid tag (i.e.: vX.Y.Z) or press Enter to default to 'latest': " RETAKE_APP_TAG
     if [ -n "$RETAKE_APP_TAG" ]; then
         export RETAKE_APP_TAG="${RETAKE_APP_TAG:-latest}"
     else
@@ -49,7 +49,7 @@ else
 fi
 echo ""
 
-if ! [ -n "${DOMAIN:-}" ]; then
+if ! [ -z "${DOMAIN:-}" ]; then
     export DOMAIN=$DOMAIN
 else
     echo "Let's get the exact domain Retake will be installed on. This will be used for TLS 🔐."
@@ -79,7 +79,7 @@ sudo -E docker-compose -f docker-compose.yml stop &> /dev/null || true
 # Retake uses basic telemetry to monitor usage (number of deployments, and number
 # of search queries per deployment). If you prefer not to be included in our telemetry,
 # simply set TELEMETRY=disabled in your .env file.
-if ! [ -n "${TELEMETRY:-}" ]; then
+if ! [ -z "${TELEMETRY:-}" ]; then
     if [ "${TELEMETRY}" == "disabled" ]; then
         echo "Telemetry successfully disabled -- Retake will not get any usage data from your deployment."
         echo "Retake has very light telemetry (i.e.: is your deploy running, and how many search queries are you running?)."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - core
     environment:
       API_KEY: retake-test-key
+      POSTHOG_API_KEY: posthog-test-key
       OPENSEARCH_HOST: core
       OPENSEARCH_PORT: 9200
       OPENSEARCH_USER: admin

--- a/poetry.lock
+++ b/poetry.lock
@@ -62,6 +62,17 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "black"
 version = "23.7.0"
 description = "The uncompromising code formatter."
@@ -909,6 +920,17 @@ docs = ["sphinx"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "monotonic"
+version = "1.6"
+description = "An implementation of time.monotonic() for Python 2 & < 3.3"
+optional = false
+python-versions = "*"
+files = [
+    {file = "monotonic-1.6-py2.py3-none-any.whl", hash = "sha256:68687e19a14f11f26d140dd5c86f3dba4bf5df58003000ed467e0e2a69bca96c"},
+    {file = "monotonic-1.6.tar.gz", hash = "sha256:3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7"},
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
@@ -1149,6 +1171,7 @@ files = [
     {file = "Pillow-10.0.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:3b08d4cc24f471b2c8ca24ec060abf4bebc6b144cb89cba638c720546b1cf538"},
     {file = "Pillow-10.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d737a602fbd82afd892ca746392401b634e278cb65d55c4b7a8f48e9ef8d008d"},
     {file = "Pillow-10.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:3a82c40d706d9aa9734289740ce26460a11aeec2d9c79b7af87bb35f0073c12f"},
+    {file = "Pillow-10.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:bc2ec7c7b5d66b8ec9ce9f720dbb5fa4bace0f545acd34870eff4a369b44bf37"},
     {file = "Pillow-10.0.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:d80cf684b541685fccdd84c485b31ce73fc5c9b5d7523bf1394ce134a60c6883"},
     {file = "Pillow-10.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76de421f9c326da8f43d690110f0e79fe3ad1e54be811545d7d91898b4c8493e"},
     {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81ff539a12457809666fef6624684c008e00ff6bf455b4b89fd00a140eecd640"},
@@ -1158,6 +1181,7 @@ files = [
     {file = "Pillow-10.0.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d50b6aec14bc737742ca96e85d6d0a5f9bfbded018264b3b70ff9d8c33485551"},
     {file = "Pillow-10.0.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:00e65f5e822decd501e374b0650146063fbb30a7264b4d2744bdd7b913e0cab5"},
     {file = "Pillow-10.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:f31f9fdbfecb042d046f9d91270a0ba28368a723302786c0009ee9b9f1f60199"},
+    {file = "Pillow-10.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:1ce91b6ec08d866b14413d3f0bbdea7e24dfdc8e59f562bb77bc3fe60b6144ca"},
     {file = "Pillow-10.0.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:349930d6e9c685c089284b013478d6f76e3a534e36ddfa912cde493f235372f3"},
     {file = "Pillow-10.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3a684105f7c32488f7153905a4e3015a3b6c7182e106fe3c37fbb5ef3e6994c3"},
     {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4f69b3700201b80bb82c3a97d5e9254084f6dd5fb5b16fc1a7b974260f89f43"},
@@ -1220,6 +1244,29 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "posthog"
+version = "3.0.1"
+description = "Integrate PostHog into any python application."
+optional = false
+python-versions = "*"
+files = [
+    {file = "posthog-3.0.1-py2.py3-none-any.whl", hash = "sha256:9c7f92fecc713257d4b2710d05b456569c9156fbdd3e85655ba7ba5ba6c7b3ae"},
+    {file = "posthog-3.0.1.tar.gz", hash = "sha256:57d2791ff5752ce56ba0f9bb8876faf3ca9208f1c2c6ceaeb5a2504c34493767"},
+]
+
+[package.dependencies]
+backoff = ">=1.10.0"
+monotonic = ">=1.5"
+python-dateutil = ">2.1"
+requests = ">=2.7,<3.0"
+six = ">=1.5"
+
+[package.extras]
+dev = ["black", "flake8", "flake8-print", "isort", "pre-commit"]
+sentry = ["django", "sentry-sdk"]
+test = ["coverage", "flake8", "freezegun (==0.3.15)", "mock (>=2.0.0)", "pylint", "pytest"]
 
 [[package]]
 name = "psycopg2-binary"
@@ -2607,4 +2654,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "362f42787c277dcaf0f49024bf78fab52e57b55e47c6a8cddb5dbbeb20608859"
+content-hash = "5300aa2af623b1ce8263c286e566e770365df425ec73cb7131d1fe7c40fcac07"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ confluent-kafka = "^2.2.0"
 loguru = "^0.7.0"
 retakesearch-py = "^2.2.0"
 retake-pgsync = "^2.5.1"
+posthog = "^3.0.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
Right now, we have no way of knowing whether people are deploying and running Retake on their own environments. This PR adds basic telemetry and improves the deploy script so that we can know whether users are running Retake.