### PR TITLE
feat: Add PostHog key

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -88,10 +88,6 @@ if [ -n "${TELEMETRY:-}" ]; then
         echo "We never collect actual search queries, or PII. If this telemetry is okay with you, please consider re-enabling it."
         echo "Much love <3!"
     fi
-else
-    # Temporary, until we get onboarded onto PostHog
-    curl -X POST -H 'Content-type: application/json' --data '{"text":"A new user deployed our docker-compose stack!"}' https://hooks.slack.com/services/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
-    export TELEMETRY=$TELEMETRY
 fi
 
 echo "Grabbing latest APT caches..."

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,7 +21,7 @@ services:
     command: uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload
     environment:
       API_KEY: retake-test-key
-      POSTHOG_API_KEY: posthog-test-key
+      POSTHOG_API_KEY: N/A
       OPENSEARCH_HOST: core
       OPENSEARCH_PORT: 9200
       OPENSEARCH_USER: admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - core
     environment:
       API_KEY: retake-test-key
-      POSTHOG_API_KEY: posthog-test-key
+      POSTHOG_API_KEY: phc_KiWfPSoxQLmFxY5yOODDBzzP3EcyPbn9oSVtsCBbasj
       OPENSEARCH_HOST: core
       OPENSEARCH_PORT: 9200
       OPENSEARCH_USER: admin


### PR DESCRIPTION
This PR adds a write-only PostHog key so that when users deploy our Dockerfile, we get telemetry on usage. This is optional, and can be disabled in the deploy script or by removing the key.

Note that right now, the only telemetry we have is whether a user has ran our docker-compose.yml file. We could add more telemetry for when they run search queries.