### PR TITLE
fix: Document that typescript client functions are async and fix typo

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -122,7 +122,7 @@ const table = new Table({
 });
 
 // Create an index
-const index = client.create_index("table_name");
+const index = await client.createIndex("table_name");
 
 // Populate the index with data from your table
 // Note: The table must have a primary key

--- a/docs/search/overview.mdx
+++ b/docs/search/overview.mdx
@@ -52,7 +52,7 @@ import { matchQuery } from "retake-search/helpers";
 const client = new Client("retake-test-key", "http://localhost:8000");
 
 // Use client.createIndex if the index doesn't exist
-const index = client.getIndex("my_index");
+const index = await client.getIndex("my_index");
 
 // Construct query
 const query = Search().query(matchQuery("questions", "Who am I?"));

--- a/docs/typescript/client.mdx
+++ b/docs/typescript/client.mdx
@@ -28,7 +28,7 @@ const client = Client("retake-test-key", "http://localhost:8000");
 Creates an empty index.
 
 ```typescript Typescript
-const index = client.createIndex("test_index");
+const index = await client.createIndex("test_index");
 ```
 
 **Parameters**
@@ -39,14 +39,14 @@ const index = client.createIndex("test_index");
 
 **Returns**
 
-An [`Index`](/typescript/index) object.
+`Promise<Index>`
 
 ### `getIndex`
 
 Gets an index.
 
 ```typescript Typescript
-const index = client.getIndex("test_index");
+const index = await client.getIndex("test_index");
 ```
 
 **Parameters**
@@ -57,7 +57,7 @@ const index = client.getIndex("test_index");
 
 **Returns**
 
-An [`Index`](/typescript/index) object.
+`Promise<Index>`
 
 ### `deleteIndex`
 


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
- Typescript docs had a typo with an incorrect function name
- It was not documented that `get_index` and `create_index` are async

**Why**

**How**

**Tests**
