### PR TITLE
fix: Don't bundle React into Node library (HOTFIX)

### DIFF
--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -42,9 +42,5 @@
   "dependencies": {
     "ky": "^0.33.3",
     "opensearch-js": "github:getretake/opensearch-js"
-  },
-  "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
   }
 }

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,4 +1,3 @@
-export * from "./components"
 export * from "./lib/client"
 export * from "./lib/index"
 export * from "./lib/search"

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../../clients/typescript": {
       "name": "retake-search",
-      "version": "1.0.10",
+      "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ky": "^0.33.3",
@@ -53,10 +53,6 @@
         "rimraf": "^5.0.1",
         "rollup": "^3.26.3",
         "typescript": "^5.1.6"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
- We were importing React components and requiring a react peer dependency in the TS library, which was breaking for clients in non-React environments

**Why**

**How**

**Tests**
