### PR TITLE
ci: Build before publish

### DIFF
--- a/.github/workflows/publish-retake-to-npm.yml
+++ b/.github/workflows/publish-retake-to-npm.yml
@@ -37,7 +37,11 @@ jobs:
 
       - name: Install Dependencies
         working-directory: clients/typescript
-        run: npm install && npm ci
+        run: npm install
+
+      - name: Build Retake
+        working-directory: clients/typescript
+        run: npm run build
 
       - name: Build and Publish to NPM
         working-directory: clients/typescript


### PR DESCRIPTION
There was a small issue in our CI where we published a non-built version to NPM