### PR TITLE
feat: add dedicated ml node, use recommended settings for core

### DIFF
--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -5,7 +5,32 @@ version: "3.8"
 services:
   core:
     image: opensearchproject/opensearch:2.9.0
+    container_name: core
     environment:
+      - cluster.name=opensearch-cluster
+      - node.name=core
+      - discovery.seed_hosts=core,ml-node
+      - cluster.initial_cluster_manager_nodes=core
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - plugins.ml_commons.model_access_control_enabled=true
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+
+  ml-node:
+    image: opensearchproject/opensearch:2.9.0
+    container_name: ml-node
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=ml-node
+      - node.roles=ml
+      - discovery.seed_hosts=core,ml-node
+      - cluster.initial_cluster_manager_nodes=core
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       - plugins.ml_commons.model_access_control_enabled=true
@@ -21,6 +46,7 @@ services:
     image: retake/retakesearch:latest
     depends_on:
       - core
+      - ml-node
     environment:
       API_KEY: retake-test-key
       OPENSEARCH_HOST: core
@@ -47,6 +73,7 @@ services:
       com.label-schema.service-type: "daemon"
     depends_on:
       - core
+      - ml-node
       - api
       - redis
     environment:

--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -6,11 +6,16 @@ services:
   core:
     image: opensearchproject/opensearch:2.9.0
     environment:
-      - discovery.type=single-node
-      - plugins.security.disabled=false
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       - plugins.ml_commons.model_access_control_enabled=true
-      - plugins.ml_commons.only_run_on_ml_node=true
-      - node.roles=master,data,ml,ingest,remote_cluster_client
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
 
   api:
     image: retake/retakesearch:latest

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -10,6 +10,11 @@ services:
     ports:
       - 9200:9200
 
+  ml-node:
+    extends:
+      file: ./docker-compose.base.yml
+      service: ml-node
+
   api:
     build:
       context: ..

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -8,6 +8,11 @@ services:
       file: ./docker-compose.base.yml
       service: core
 
+  ml-node:
+    extends:
+      file: ./docker-compose.base.yml
+      service: ml-node
+
   api:
     extends:
       file: ./docker-compose.base.yml

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,13 +7,33 @@ services:
     extends:
       file: ./docker-compose.base.yml
       service: core
+    container_name: core
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=core
+      - discovery.seed_hosts=core,ml-node
+      - cluster.initial_cluster_manager_nodes=core
     ports:
       - 9200:9200
+
+  ml-node:
+    extends:
+      file: ./docker-compose.base.yml
+      service: core
+    container_name: ml-node
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=ml-node
+      - node.roles=ml
+      - discovery.seed_hosts=core,ml-node
+      - cluster.initial_cluster_manager_nodes=core
 
   api:
     extends:
       file: ./docker-compose.base.yml
       service: api
+    depends_on:
+      - ml-node
     ports:
       - 8000:8000
     environment:
@@ -30,5 +50,7 @@ services:
     extends:
       file: ./docker-compose.base.yml
       service: pgsync
+    depends_on:
+      - ml-node
     ports:
       - 7433:7433

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,26 +7,13 @@ services:
     extends:
       file: ./docker-compose.base.yml
       service: core
-    container_name: core
-    environment:
-      - cluster.name=opensearch-cluster
-      - node.name=core
-      - discovery.seed_hosts=core,ml-node
-      - cluster.initial_cluster_manager_nodes=core
     ports:
       - 9200:9200
 
   ml-node:
     extends:
       file: ./docker-compose.base.yml
-      service: core
-    container_name: ml-node
-    environment:
-      - cluster.name=opensearch-cluster
-      - node.name=ml-node
-      - node.roles=ml
-      - discovery.seed_hosts=core,ml-node
-      - cluster.initial_cluster_manager_nodes=core
+      service: ml-node
 
   api:
     extends:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -8,6 +8,11 @@ services:
       file: ../docker/docker-compose.dev.yml
       service: core
 
+  ml-node:
+    extends:
+      file: ../docker/docker-compose.dev.yml
+      service: ml-node
+
   api:
     extends:
       file: ../docker/docker-compose.dev.yml


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #110

**What**
Introduces a dedicated ml node for running models and adds recommended settings pulled from the official opensearch docker compose file.

**Why**
Because running models has different requirements and shouldn't be done on a data node.

**How**
- Add the `ml-node` to the main docker compose file
- Add recommended settings to the core service

**Tests**
None, run docker compose directly and confirm cluster starts successfully.