### PR TITLE
fix: domain input in deploy script and hang

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -18,6 +18,7 @@ services:
       file: ./docker-compose.base.yml
       service: api
     environment:
+      API_KEY: ${API_KEY}
       POSTHOG_API_KEY: phc_KiWfPSoxQLmFxY5yOODDBzzP3EcyPbn9oSVtsCBbasj
 
   redis:


### PR DESCRIPTION
**Ticket(s) Closed**
N/A

**What**
Fix an issue with the deploy script not reading the domain input properly, and fix an issue that caused the final part to hang while waiting retake to be ready.

**Why**
The deploy script didn't work as intended.

**How**
- Create .env file with API_KEY to override docker compose environment
- Generate api key in deploy script
- Fix conditions when getting user input

**Tests**
Run the deploy script and confirm it doesn't hang and you can access retake on the domain you enter.