### PR TITLE
feat: Add commit hash to Dockerfile for telemetry

### DIFF
--- a/.github/workflows/publish-retake-to-dockerhub.yml
+++ b/.github/workflows/publish-retake-to-dockerhub.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v3
 
+      - name: Set COMMIT_SHA Environment Variable
+        run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -53,6 +56,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          build-args: COMMIT_SHA=${{ env.COMMIT_SHA }}
           platforms: linux/amd64,linux/arm64
           file: ./docker/search.Dockerfile
           push: true

--- a/api/app.py
+++ b/api/app.py
@@ -33,8 +33,8 @@ if POSTHOG_API_KEY != "" and TELEMETRY != "disabled":
         str(uuid.uuid4()),
         "New Retake Deployment",
         {
-            "commit_sha": COMMIT_SHA,
-        },
+            "Commit SHA": COMMIT_SHA
+        }
     )
 else:
     logging.info("Telemetry disabled")

--- a/api/app.py
+++ b/api/app.py
@@ -19,6 +19,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logging.basicConfig(level=logging.INFO)
 
 API_KEY = os.getenv("API_KEY", "")
+COMMIT_SHA = os.getenv("COMMIT_SHA", "")
 POSTHOG_API_KEY = os.getenv("POSTHOG_API_KEY", "")
 TELEMETRY = os.getenv("TELEMETRY", "enabled")
 
@@ -28,7 +29,13 @@ if POSTHOG_API_KEY != "" and TELEMETRY != "disabled":
     posthog = Posthog(project_api_key=POSTHOG_API_KEY, host="https://app.posthog.com")
 
     # Keep all telemetry as anonymous
-    posthog.capture(str(uuid.uuid4()), "New Retake Deployment")
+    posthog.capture(
+        str(uuid.uuid4()),
+        "New Retake Deployment",
+        {
+            "commit_sha": COMMIT_SHA,
+        },
+    )
 else:
     logging.info("Telemetry disabled")
 

--- a/api/app.py
+++ b/api/app.py
@@ -30,11 +30,7 @@ if POSTHOG_API_KEY != "" and TELEMETRY != "disabled":
 
     # Keep all telemetry as anonymous
     posthog.capture(
-        str(uuid.uuid4()),
-        "New Retake Deployment",
-        {
-            "Commit SHA": COMMIT_SHA
-        }
+        str(uuid.uuid4()), "New Retake Deployment", {"Commit SHA": COMMIT_SHA}
     )
 else:
     logging.info("Telemetry disabled")

--- a/docker/search.Dockerfile
+++ b/docker/search.Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.9-slim
 
 WORKDIR /app
 
+ARG COMMIT_SHA
+
 # Install poetry
 RUN apt-get update && apt-get install -y curl && \
     curl -sSL https://install.python-poetry.org | python -

--- a/docker/search.Dockerfile
+++ b/docker/search.Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.9-slim
 WORKDIR /app
 
 ARG COMMIT_SHA
+ENV COMMIT_SHA=$COMMIT_SHA
 
 # Install poetry
 RUN apt-get update && apt-get install -y curl && \

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ fake = Faker()
 
 def generate_random_vector(dim=20, min_val=-1, max_val=1):
     vector = [random.uniform(min_val, max_val) for _ in range(dim)]
-    magnitude = math.sqrt(sum([x**2 for x in vector]))
+    magnitude = math.sqrt(sum([x ** 2 for x in vector]))
     return [x / magnitude for x in vector]
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ fake = Faker()
 
 def generate_random_vector(dim=20, min_val=-1, max_val=1):
     vector = [random.uniform(min_val, max_val) for _ in range(dim)]
-    magnitude = math.sqrt(sum([x ** 2 for x in vector]))
+    magnitude = math.sqrt(sum([x**2 for x in vector]))
     return [x / magnitude for x in vector]
 
 


### PR DESCRIPTION
Closes #237 

I had a minute. This will add the commit hash to our Telemetry events from PostHog, which helps debug issues that users might face

Tested here:
<img width="741" alt="Capture d’écran, le 2023-08-15 à 15 57 59" src="https://github.com/getretake/retake/assets/21990816/a78c0b21-964b-44cb-884c-1b10216c7daa">
